### PR TITLE
Changing the API for column and view creation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,11 @@
     [ ] Show how this all works with the the load_dataframe method
 
 
+# For Testing
+
+[ ] Add test to make sure that user-added namespaces don't get linked to other users
+
+
 # Ideas
 [ ] Maybe cache all of the columns in the database on the local machine so
     validation can be done locally? Periodically checks for columns can be done

--- a/gerrydb/repos/namespace.py
+++ b/gerrydb/repos/namespace.py
@@ -9,6 +9,7 @@ from gerrydb.repos.base import (
     normalize_path,
     online,
     write_context,
+    normalize_path,
 )
 from gerrydb.schemas import Namespace, NamespaceCreate
 
@@ -79,6 +80,7 @@ class NamespaceRepo(NamespacedObjectRepo):
         Returns:
             The new namespace.
         """
+        path = normalize_path(path, path_length=1)
         response = self.ctx.client.post(
             "/namespaces/",
             json=NamespaceCreate(

--- a/gerrydb/repos/view.py
+++ b/gerrydb/repos/view.py
@@ -422,7 +422,8 @@ class ViewRepo(NamespacedObjectRepo[ViewMeta]):
                 if the parameters fail validation, or if no namespace is provided.
         """
         gpkg_path = self.session.cache.get_view_gpkg(
-            namespace=normalize_path(namespace), path=normalize_path(path)
+            namespace=normalize_path(namespace, path_length=1),
+            path=normalize_path(path),
         )
         if gpkg_path is None:
             gpkg_path = self._get(path, namespace, request_timeout)
@@ -448,7 +449,7 @@ class ViewRepo(NamespacedObjectRepo[ViewMeta]):
             gpkg_render_id = gpkg_response.headers["x-gerrydb-view-render-id"]
 
         return self.session.cache.upsert_view_gpkg(
-            namespace=normalize_path(namespace),
+            namespace=normalize_path(namespace, path_length=1),
             path=normalize_path(path),
             render_id=gpkg_render_id,
             content=gpkg_response.content,

--- a/gerrydb/repos/view_template.py
+++ b/gerrydb/repos/view_template.py
@@ -7,9 +7,78 @@ from gerrydb.repos.base import (
     err,
     namespaced,
     online,
+    normalize_path,
     write_context,
 )
 from gerrydb.schemas import Column, ColumnSet, ViewTemplate, ViewTemplateCreate
+
+
+def _normalize_columns(
+    namespace: str, columns: Collection[Union[Column, str]]
+) -> list[str]:
+    """
+    Constructs normalized paths of the columns objects that are passed in.
+
+    Args:
+        namespace: Namespace to use for the columns.
+        columns: Columns to normalize.
+
+    Returns:
+        List of normalized paths of the columns.
+    """
+    return_list = []
+
+    for item in columns:
+        if isinstance(item, Column):
+            return_list.append(item.path_with_resource)
+        else:
+            item = normalize_path(item)
+            split_path = item.split("/")
+            if len(split_path) == 1:
+                return_list.append(f"/columns/{namespace}/{split_path[0]}")
+            elif len(split_path) == 3:
+                return_list.append(f"columns/{namespace}/{split_path[-1]}")
+            else:
+                raise ValueError(
+                    f"Column path must be in the form of either "
+                    "/columns/namespace/column_name or just column_name"
+                )
+
+    return return_list
+
+
+def _normalize_column_sets(
+    namespace: str, column_sets: Collection[Union[ColumnSet, str]]
+) -> list[str]:
+    """
+    Constructs normalized paths of the column sets objects that are passed in.
+
+    Args:
+        namespace: Namespace to use for the column sets.
+        column_sets: Column sets to normalize.
+
+    Returns:
+        List of normalized paths of the column sets.
+    """
+    return_list = []
+
+    for item in column_sets:
+        if isinstance(item, Column):
+            return_list.append(item.path_with_resource)
+        else:
+            item = normalize_path(item)
+            split_path = item.split("/")
+            if len(split_path) == 1:
+                return_list.append(f"/column-sets/{namespace}/{split_path[0]}")
+            elif len(split_path) == 3:
+                return_list.append(f"/column-sets/{namespace}/{split_path[-1]}")
+            else:
+                raise ValueError(
+                    f"Column_set path must be in the form of either "
+                    "/column-sets/namespace/column_set_name or just column_set_name"
+                )
+
+    return return_list
 
 
 class ViewTemplateRepo(NamespacedObjectRepo[ViewTemplate]):
@@ -24,13 +93,24 @@ class ViewTemplateRepo(NamespacedObjectRepo[ViewTemplate]):
         path: str,
         namespace: Optional[str] = None,
         *,
-        members: Collection[Union[Column, ColumnSet, str]],
+        columns: Optional[Collection[Union[Column, str]]] = list(),
+        column_sets: Optional[Collection[Union[ColumnSet, str]]] = list(),
         description: str,
     ) -> ViewTemplate:
         """Creates a view template.
 
         Args:
             path: Short identifier for the view template.
+            namespace: Namespace to create the view template in.
+            columns: Columns to include in the view template. The columns can be either
+                a `Column` object or a string representing the column name of the form
+                `{column_name}` or `/columns/{namespace}/{column_name}`. In the event that
+                the namespace is not provided, the namespace of the ViewTemplate will be used.
+            column_sets: Column sets to include in the view template. The column sets can be either
+                a `ColumnSet` object or a string representing the column set name of the form
+                `{column_set_name}` or `/column-sets/{namespace}/{column_set_name}`. In the event
+                that the namespace is not provided, the namespace of the ViewTemplate will be used.
+            description: Description of what is contained in the view template.
 
         Raises:
             RequestError: If the view template cannot be created on the server side,
@@ -39,15 +119,33 @@ class ViewTemplateRepo(NamespacedObjectRepo[ViewTemplate]):
         Returns:
             Metadata for the new column.
         """
+        assert (
+            isinstance(columns, list)
+            or isinstance(columns, set)
+            or isinstance(columns, tuple)
+        ), "'columns' must be a list, set, or tuple"
+        assert (
+            isinstance(column_sets, list)
+            or isinstance(column_sets, set)
+            or isinstance(column_sets, tuple)
+        ), "'column_sets' must be a list, set, or tuple"
+
+        if len(columns) == 0 and len(column_sets) == 0:
+            raise ValueError("Must provide at least one of columns or column_sets.")
+
+        members = []
+
+        if len(columns) > 0:
+            members.extend(_normalize_columns(namespace, columns))
+        if len(column_sets) > 0:
+            members.extend(_normalize_column_sets(namespace, column_sets))
+
         response = self.ctx.client.post(
             f"{self.base_url}/{namespace}",
             json=ViewTemplateCreate(
                 path=path,
                 namespace=namespace,
-                members=[
-                    member if isinstance(member, str) else member.path_with_resource
-                    for member in members
-                ],
+                members=members,
                 description=description,
             ).dict(),
         )

--- a/tests/repos/test_view.py
+++ b/tests/repos/test_view.py
@@ -8,7 +8,7 @@ def test_view_repo_create__valid(client_with_ia_layer_loc, ia_dataframe):
     client_ns, layer, locality, columns = client_with_ia_layer_loc
     with client_ns.context(notes="Creating a view template and view for Iowa") as ctx:
         view_template = ctx.view_templates.create(
-            path="valid_test", members=list(columns.values()), description="Base view."
+            path="valid_test", columns=list(columns.values()), description="Base view."
         )
         view = ctx.views.create(
             path="ia_valid_test",
@@ -29,7 +29,7 @@ def ia_view(client_with_ia_layer_loc):
     client_ns, layer, locality, columns = client_with_ia_layer_loc
     with client_ns.context(notes="Creating a view template and view for Iowa") as ctx:
         view_template = ctx.view_templates.create(
-            path="base", members=list(columns.values()), description="Base view."
+            path="base", columns=list(columns.values()), description="Base view."
         )
         return ctx.views.create(
             path="ia_base",
@@ -45,7 +45,7 @@ def ia_view_with_graph(client_with_ia_layer_loc, ia_graph):
     client_ns, layer, locality, columns = client_with_ia_layer_loc
     with client_ns.context(notes="Creating a view template and view for Iowa") as ctx:
         view_template = ctx.view_templates.create(
-            path="graph_base", members=list(columns.values()), description="Base view."
+            path="graph_base", columns=list(columns.values()), description="Base view."
         )
         graph = ctx.graphs.create(
             path="ia_counties",

--- a/tests/repos/test_view_template.py
+++ b/tests/repos/test_view_template.py
@@ -11,7 +11,7 @@ def test_view_template_repo_create_get__online_columns_only(
         pop_col = ctx.columns.create(**pop_column_meta)
         vap_col = ctx.columns.create(**vap_column_meta)
         view_template = ctx.view_templates.create(
-            path="pops", members=[pop_col, vap_col], description="Population view."
+            path="pops", columns=[pop_col, vap_col], description="Population view."
         )
         # print(view_template)
         # TODO: more evaluation here.


### PR DESCRIPTION
This makes it so that the user does not need to remember the full path in order to add columns and column sets to a view as well as separating out the columns and the column sets that you are adding to the view