### PR TITLE
Wip/caching optimization

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
           --health-retries 10
     strategy:
       matrix:
-        python-version: ['3.10', '3.12']
+        python-version: ['3.12']
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
@@ -66,8 +66,10 @@ jobs:
         pip install --upgrade pip
         pip install poetry
         pip install black isort
+        pip install colorlog
         pip install ./gerrydb-client-py/
         pip install ./gerrydb-meta/
+        pip install --upgrade geopandas
 
     - name: Set up GerryDB and get API key
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+*.ipynb
 
 # IPython
 profile_default/
@@ -122,6 +123,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.gerryrc
 env/
 venv/
 ENV/

--- a/gerrydb/cache.py
+++ b/gerrydb/cache.py
@@ -54,6 +54,68 @@ class GerryCache:
         self.data_dir = data_dir
         self.max_size_gb = max_size_gb
 
+    def upsert_graph_gpkg(
+        self, namespace: str, path: str, render_id: str, content: bytes
+    ) -> Path:
+        gpkg_path = self.data_dir / f"{render_id}.gpkg"
+        with open(gpkg_path, "wb") as gpkg_fp:
+            bytes_written = gpkg_fp.write(content)
+
+        with self._conn:
+            prev_render_id = self._conn.execute(
+                "SELECT render_id FROM graph WHERE namespace = ? AND path = ?",
+                (namespace, path),
+            ).fetchone()
+            if prev_render_id is not None:
+                self._conn.execute(
+                    "DELETE FROM graph WHERE namespace = ? AND path = ?",
+                    (namespace, path),
+                )
+                print("The previous render id is", prev_render_id)
+                for ext in CACHE_EXTENSIONS:
+                    Path(self.data_dir / f"{prev_render_id[0]}.{ext}").unlink(
+                        missing_ok=True
+                    )
+
+            self._conn.execute(
+                (
+                    "INSERT INTO graph (namespace, render_id, path, cached_at, file_size_kb) "
+                    "VALUES (?, ?, ?, ?, ?)"
+                ),
+                (namespace, render_id, path, datetime.now().isoformat(), bytes_written),
+            )
+
+            db_cursor = self._conn.cursor()
+
+            db_cursor.execute("SELECT SUM(file_size_kb) FROM graph")
+            total_db_size = db_cursor.fetchone()[0]
+
+            while total_db_size > self.max_size_gb * 1024 * 1024:
+                db_cursor.execute("SELECT * FROM graph ORDER BY cached_at ASC LIMIT 1")
+                oldest = db_cursor.fetchone()
+                oldest_namespace, oldest_path, oldest_render_id = (
+                    oldest[0],
+                    oldest[1],
+                    oldest[2],
+                )
+                print(f"Found oldest render: {oldest_namespace}, {oldest_path}")
+                print(oldest)
+                total_db_size -= oldest[4]
+                db_cursor.execute(
+                    "DELETE FROM graph WHERE namespace = ? AND path = ?",
+                    (oldest_namespace, oldest_path),
+                )
+
+                print(f"The new db size is", total_db_size)
+                print(f"Now deleting the render file: {oldest_render_id}.gpkg")
+
+                try:
+                    os.remove(self.data_dir / f"{oldest_render_id}.gpkg")
+                except FileNotFoundError:
+                    print(f"Could not find the render file: {oldest_render_id}.gpkg")
+
+        return gpkg_path
+
     def upsert_view_gpkg(
         self, namespace: str, path: str, render_id: str, content: bytes
     ) -> Path:
@@ -121,6 +183,20 @@ class GerryCache:
                 except FileNotFoundError:
                     print(f"Could not find the render file: {oldest_render_id}.gpkg")
 
+        return gpkg_path
+
+    def get_graph_gpkg(self, namespace: str, path: str) -> Optional[Path]:
+        """Returns the path to a graph's cached GeoPackage, if available."""
+        render_id = self._conn.execute(
+            "SELECT render_id FROM graph WHERE namespace = ? AND path = ?",
+            (namespace, path),
+        ).fetchone()
+        if render_id is None:
+            return None
+
+        gpkg_path = self.data_dir / f"{render_id[0]}.gpkg"
+        if not gpkg_path.is_file():
+            return None
         return gpkg_path
 
     def get_view_gpkg(self, namespace: str, path: str) -> Optional[Path]:
@@ -193,12 +269,12 @@ class GerryCache:
         )
         self._conn.execute(
             """CREATE TABLE graph(
-                render_id      TEXT       NOT NULL REFERENCES view(render_id),
-                plans          INTEGER    NOT NULL, 
-                geometry       INTEGER    NOT NULL, 
+                namespace      TEXT       NOT NULL,
+                render_id      TEXT       NOT NULL,
+                path           TEXT       NOT NULL,
                 cached_at      TIMESTAMP  NOT NULL,
                 file_size_kb   BIGINTEGER NOT NULL,
-                UNIQUE(render_id, plans, geometry)
+                UNIQUE(namespace, path)
             )"""
         )
         self._conn.execute(

--- a/gerrydb/client.py
+++ b/gerrydb/client.py
@@ -13,6 +13,9 @@ import pandas as pd
 from pandas.core.indexes.base import Index as pdIndex
 import tomlkit
 from rapidfuzz import process, fuzz
+from geoalchemy2.elements import WKBElement
+from shapely.geometry import Polygon
+import hashlib
 
 from gerrydb.cache import GerryCache
 from gerrydb.exceptions import ConfigError
@@ -44,10 +47,7 @@ from gerrydb.schemas import (
     ViewMeta,
     ViewTemplate,
 )
-
-import logging
-
-logging.getLogger("httpx").setLevel(logging.WARNING)
+from gerrydb.logging import log
 
 DEFAULT_GERRYDB_ROOT = Path(os.path.expanduser("~")) / ".gerrydb"
 
@@ -72,7 +72,7 @@ class GerryDB:
         namespace: Optional[str] = None,
         offline: bool = False,
         timeout: int = 600,
-        cache_max_size_gb: float = 20,
+        cache_max_size_gb: float = 10,
     ):
         """Creates a GerryDB session.
 
@@ -203,6 +203,7 @@ class GerryDB:
         Returns:
             A context manager for GerryDB writes.
         """
+        log.debug("Creating a write context with notes: %s", notes)
         return WriteContext(db=self, notes=notes)
 
     @property
@@ -355,16 +356,83 @@ class WriteContext:
         df: Union[pd.DataFrame, gpd.GeoDataFrame],
         *,
         namespace: str,
-        locality: Union[str, Locality],
-        layer: Union[str, GeoLayer],
+        locality: Locality,
+        layer: GeoLayer,
         batch_size: int,
         max_conns: int,
+        allow_empty_polys: bool = False,
     ) -> None:
         """
         Private method called by the `load_dataframe` method to load geometries
         into the database.
 
         Adds the geometries in the 'geometry' column of the dataframe to the database.
+
+        Args:
+            df: The dataframe containing the geometries to be added.
+            namespace: The namespace to which the geometries belong.
+            locality: The locality to which the geometries belong. (e.g. 'pennsylvania')
+            layer: The layer to which the geometries belong. (e.g. 'vtd')
+            batch_size: The number of rows to import per batch.
+            max_conns: The maximum number of simultaneous connections to the API.
+
+        """
+        if "geometry" in df.columns:
+            df = df.to_crs("epsg:4269")  # import as lat/long
+            geos = dict(df.geometry)
+        else:
+            geos = {key: Polygon() for key in df.index}
+
+        # Augment geographies with internal points if available.
+        if "internal_point" in df.columns:
+            internal_points = dict(df.internal_point)
+            geos = {path: (geo, internal_points[path]) for path, geo in geos.items()}
+
+        if layer.namespace != namespace:
+            self.db.geo.fork_geos(
+                path=locality.canonical_path,
+                namespace=namespace,
+                layer_name=layer.path,
+                source_namespace=layer.namespace,
+                source_layer_name=layer.path,
+                allow_extra_source_geos=True,
+                allow_empty_polys=allow_empty_polys,
+            )
+        else:
+            try:
+                asyncio.run(
+                    _load_geos(self.geo, geos, namespace, batch_size, max_conns)
+                )
+
+            except Exception as e:
+                if str(e) == "Cannot create geographies that already exist.":
+                    # TODO: Make this error more specific maybe?
+                    raise e
+                raise e
+
+        # Update the layer to be in the correct namespace before you map it
+        ns_layer = self.db.geo_layers[layer.path]
+        self.geo_layers.map_locality(
+            layer=ns_layer,
+            locality=locality,
+            geographies=[f"/{namespace}/{key}" for key in df.index],
+        )
+
+    def __update_geos(
+        self,
+        df: Union[pd.DataFrame, gpd.GeoDataFrame],
+        *,
+        namespace: str,
+        locality: Union[str, Locality],
+        layer: Union[str, GeoLayer],
+        batch_size: int,
+        max_conns: int,
+        allow_empty_polys: bool,
+    ) -> None:
+        """
+        Private method called by the `load_dataframe` method to update geos
+        that are already present in the database. If some geos are not present
+        in the database, this will raise an error.
 
         Args:
             df: The dataframe containing the geometries to be added.
@@ -386,34 +454,77 @@ class WriteContext:
             internal_points = dict(df.internal_point)
             geos = {path: (geo, internal_points[path]) for path, geo in geos.items()}
 
-        try:
-            asyncio.run(_load_geos(self.geo, geos, namespace, batch_size, max_conns))
+        if layer.namespace != namespace:
+            self.db.geo.fork_geos(
+                path=locality.canonical_path,
+                namespace=namespace,
+                layer_name=layer.path,
+                source_namespace=layer.namespace,
+                source_layer_name=layer.path,
+            )
+        else:
+            try:
+                asyncio.run(
+                    _update_geos(
+                        repo=self.geo,
+                        geos=geos,
+                        namespace=namespace,
+                        batch_size=batch_size,
+                        max_conns=max_conns,
+                        allow_empty_polys=allow_empty_polys,
+                    )
+                )
 
-        except Exception as e:
-            if str(e) == "Cannot create geographies that already exist.":
-                # TODO: Make this error more specific maybe?
+            except Exception as e:
+                if str(e) == "Cannot create geographies that already exist.":
+                    # TODO: Make this error more specific maybe?
+                    raise e
                 raise e
-            raise e
 
         if locality is not None and layer is not None:
+            # Update the layer to be in the correct namespace before you map it
+            ns_layer = self.db.geo_layers[layer.path]
             self.geo_layers.map_locality(
-                layer=layer,
+                layer=ns_layer,
                 locality=locality,
                 geographies=[f"/{namespace}/{key}" for key in df.index],
             )
 
-    def __validate_geos(
+    # TODO: this is not finished yet
+    def __upsert_geos(
         self,
         df: Union[pd.DataFrame, gpd.GeoDataFrame],
+        *,
+        namespace: str,
         locality: Union[str, Locality],
         layer: Union[str, GeoLayer],
+        batch_size: int,
+        max_conns: int,
+    ) -> None:
+        raise NotImplementedError("This method is not finished yet.")
+
+    def __validate_geos_compatabilty(
+        self,
+        df: Union[pd.DataFrame, gpd.GeoDataFrame],
+        locality: Locality,
+        layer: GeoLayer,
+        namespace: str,
+        allow_extra_source_geos: bool = False,
+        allow_empty_polys: bool = False,
     ):
         """
         A private method called by the `load_dataframe` method to validate that the passed
-        geometry paths exist in the database.
+        geometry paths exist in the database. This method also checks to make sure that empty
+        geometries are not uploaded unless explicitly allowed.
 
         All of the geometry paths in the dataframe must exist in a single locality and in a
         single layer. If they do not, this method will raise an error.
+
+        The geometries themselves will be created before this is called and this will
+        then be called in the same transaction to validate that we can create the corresponding
+        geo version for the geography. If the paths do not line up, that means that WKBs cannot
+        be loaded since the Geographies (paths) that they should bind to are not present in the
+        layer or namespace.
 
         Args:
             df: The dataframe containing the geometries to be added.
@@ -422,36 +533,118 @@ class WriteContext:
 
         Raises:
             ValueError: If the locality or layer is not provided.
-            ValueError: If the paths in the index of the dataframe do not match any of the paths in
+            IndexError: If the paths in the index of the dataframe do not match any of the paths in
                 the database.
             ValueError: If there are paths missing from the dataframe compared to the paths for
                 the given locality and layer in the database. All geometries must be updated
                 at the same time to avoid unintentional null values.
         """
-        if locality is None or layer is None:
-            raise ValueError(
-                "Locality and layer must be provided if create_geo is False."
+
+        locality_path = locality.canonical_path
+        layer_path = layer.path
+
+        log.debug(
+            "Checking known paths for locality '%s' in layer '%s' belonging to namespace '%s'",
+            locality_path,
+            layer_path,
+            layer.namespace,
+        )
+
+        # Grab all paths for the layer in the namespace
+        known_paths = set(
+            self.db.geo.all_paths(
+                path=locality_path,
+                layer_name=layer_path,
+                namespace=layer.namespace,
+            )
+        )
+
+        df_paths = set(df.index)
+        empty_polygon_wkb = Polygon().wkb
+        empty_hash = hashlib.md5(empty_polygon_wkb).hexdigest()
+
+        if "geometry" in df.columns:
+            df_path_hash_dict = df.geometry.apply(
+                lambda x: hashlib.md5(WKBElement(x.wkb, srid=4269).data).hexdigest()
+            ).to_dict()
+        else:
+            df_path_hash_dict = {idx: empty_hash for idx in df.index}
+
+        layer_path_hash_dict = df_path_hash_dict.copy()
+        if layer.namespace != namespace:
+            layer_path_hash_dict = dict(
+                self.db.geo.check_forkability(
+                    path=locality_path,
+                    namespace=namespace,
+                    layer_name=layer_path,
+                    source_namespace=layer.namespace,
+                    source_layer_name=layer.path,
+                    allow_extra_source_geos=allow_extra_source_geos,
+                    allow_empty_polys=allow_empty_polys,
+                )
             )
 
-        locality_path = ""
-        layer_path = ""
-
-        if isinstance(locality, Locality):
-            locality_path = locality.canonical_path
+        if df_path_hash_dict != layer_path_hash_dict:
+            if "geometry" in df.columns:
+                conflicting_paths = list(
+                    path
+                    for path in df_path_hash_dict
+                    if layer_path_hash_dict[path] != df_path_hash_dict[path]
+                )
+                raise ValueError(
+                    "Conflicting geometries found in dataframe and passed layer. "
+                    "The following paths have conflicting geometries in the dataframe's "
+                    f"geometry column and the layer {layer.path} in the namespace "
+                    f"{layer.namespace}: "
+                    f"{conflicting_paths}"
+                )
         else:
-            locality_path = locality
-        if isinstance(layer, GeoLayer):
-            layer_path = layer.path
-        else:
-            layer_path = layer
+            if (
+                layer.namespace == namespace
+                and any([val == empty_hash for val in df_path_hash_dict.values()])
+                and not allow_empty_polys
+            ):
+                if "geometry" in df.columns:
+                    raise ValueError(
+                        "The 'geometry' column in the dataframe contains empty polygons "
+                        "but empty polygons have not been allowed explicitly. If you would like "
+                        "to allow for the creation of empty polygons, please pass the value "
+                        "`allow_empty_polys=True` to the `load_dataframe` method."
+                    )
 
-        known_paths = set(self.db.geo.all_paths(locality_path, layer_path))
-        df_paths = set(df.index)
+                raise ValueError(
+                    "No 'geometry' column found in dataframe and empty polygons "
+                    "have not been allowed explicitly. If you would like to allow"
+                    "for the creation of empty polygons, please pass the value "
+                    "`allow_empty_polys=True` to the `load_dataframe` method."
+                )
+
+            if (
+                layer.namespace != namespace
+                and any([val == empty_hash for val in layer_path_hash_dict.values()])
+                and not allow_empty_polys
+            ):
+                raise ValueError(
+                    f"Attempted to fork geometries from layer {layer.path} in namespace "
+                    f"{layer.namespace} to layer {layer.path} in namespace {namespace}. "
+                    f"However, some of the source geometries in '{layer.namespace}/{layer.path}' "
+                    f"are empty polygons and empty polygons have not been allowed explicitly. "
+                    "If you would like to allow for the creation of empty polygons, please pass "
+                    "the value `allow_empty_polys=True` to the `load_dataframe` method."
+                )
+
+        log.debug("Known paths: %s", known_paths)
 
         if df_paths - known_paths == df_paths:
-            raise ValueError(
+            example_found_path = (
+                list(known_paths)[0]
+                if len(known_paths) > 0
+                else "NO GEOGRAPHIES FOUND IN NAMESPACE MATCHING GIVEN LOCALITY AND LAYER"
+            )
+
+            raise IndexError(
                 f"The index of the dataframe does not appear to match any geographies in the namespace "
-                f"which have the following geoid format: '{list(known_paths)[0] if len(known_paths) > 0 else None}'. "
+                f"which have the following geoid format: '{example_found_path}'. "
                 f"Please ensure that the index of the dataframe matches the format of the geoid."
             )
 
@@ -469,7 +662,8 @@ class WriteContext:
                 f"'{layer_path}' and locality '{locality_path}', but the passed dataframe "
                 f"does not contain the following geographies: "
                 f"{known_paths - df_paths}. "
-                f"Please provide values for these geographies in the dataframe."
+                f"Please provide values for these geographies in the dataframe "
+                f"or create a new locality with only the relevant geographies."
             )
 
     def __validate_columns(self, columns):
@@ -546,12 +740,76 @@ class WriteContext:
                 f"Please create the missing columns first using the `db.columns.create` method."
             )
 
+    def __validate_load_types(
+        self,
+        df: Union[pd.DataFrame, gpd.GeoDataFrame],
+        *,
+        namespace: Optional[str],
+        locality: Optional[Union[str, Locality]],
+        layer: Optional[Union[str, GeoLayer]],
+        create_geos: bool,
+        patch_geos: bool,
+        upsert_geos: bool,
+        allow_empty_polys: bool,
+    ):
+        if namespace is None:
+            raise ValueError("No Namespace provided.")
+
+        if create_geos or upsert_geos:
+            if locality is None:
+                raise ValueError(
+                    "Locality must be provided when creating or upserting Geos"
+                )
+
+            if layer is None:
+                raise ValueError(
+                    "GeoLayer must be provided when creating or upserting Geos"
+                )
+
+        assert (
+            isinstance(create_geos, bool)
+            and isinstance(patch_geos, bool)
+            and isinstance(upsert_geos, bool)
+        )
+
+        if not ([create_geos, patch_geos, upsert_geos].count(True) <= 1):
+            raise ValueError(
+                "Exactly one of `create_geo`, `patch_geos`, or `upsert_geos` must be True, or"
+                " all must be False."
+            )
+
+        if patch_geos or not (create_geos | upsert_geos | patch_geos):
+            # This checks that the geos are good in the locality
+            # If we plan to fork the geos, we need to check that the source and target
+            # namespaces are compatible.
+            log.debug("VALIDATING GEOS BETWEEN SOURCE AND TARGET NAMESPACES")
+            self.__validate_geos_compatabilty(
+                df=df,
+                namespace=namespace,
+                locality=locality,
+                layer=layer,
+                allow_empty_polys=allow_empty_polys,
+            )
+
+        if create_geos and (layer.namespace != namespace):
+            self.__validate_geos_compatabilty(
+                df=df,
+                namespace=namespace,
+                locality=locality,
+                layer=layer,
+                allow_extra_source_geos=True,
+                allow_empty_polys=allow_empty_polys,
+            )
+
     def load_dataframe(
         self,
         df: Union[pd.DataFrame, gpd.GeoDataFrame],
         columns: Union[pdIndex, list[str], dict[str, Column]],
         *,
-        create_geo: bool = False,
+        create_geos: bool = False,
+        patch_geos: bool = False,
+        upsert_geos: bool = False,
+        allow_empty_polys: bool = False,
         namespace: Optional[str] = None,
         locality: Optional[Union[str, Locality]] = None,
         layer: Optional[Union[str, GeoLayer]] = None,
@@ -587,18 +845,59 @@ class WriteContext:
             columns: Mapping between column names in `df` and GerryDB column metadata.
                 Only columns included in the mapping will be imported.
             create_geo: Determines whether to create geographies from the DataFrame.
+            patch_geos: Determines whether to update existing geographies from the DataFrame.
+            upsert_geos: Combination of create and patch. If the geographies exist, they will be
+                updated. If they do not exist, they will be created.
             namespace: Namespace to load geographies into.
             locality: `Locality` to associate a new `GeoSet` with.
             layer: `GeoLayer` to associate a new `GeoSet` with.
             batch_size: Number of rows to import per API request batch.
             max_conns: Maximum number of simultaneous API connections.
         """
+        log.debug("IN THE LOAD FUNCTION")
         namespace = self.db.namespace if namespace is None else namespace
-        if namespace is None:
-            raise ValueError("No namespace available.")
 
-        if create_geo:
+        self.__validate_load_types(
+            df=df,
+            namespace=namespace,
+            locality=locality,
+            layer=layer,
+            create_geos=create_geos,
+            patch_geos=patch_geos,
+            upsert_geos=upsert_geos,
+            allow_empty_polys=allow_empty_polys,
+        )
+
+        if create_geos or upsert_geos:
+            if not isinstance(locality, Locality):
+                locality = self.db.localities[locality]
+
+            if not isinstance(layer, GeoLayer):
+                layer = self.db.geo_layers[layer]
+
+        if create_geos:
             self.__create_geos(
+                df=df,
+                namespace=namespace,
+                locality=locality,
+                layer=layer,
+                batch_size=batch_size,
+                max_conns=max_conns,
+                allow_empty_polys=allow_empty_polys,
+            )
+
+        if patch_geos:
+            self.__update_geos(
+                df=df,
+                namespace=namespace,
+                locality=locality,
+                layer=layer,
+                batch_size=batch_size,
+                max_conns=max_conns,
+                allow_empty_polys=allow_empty_polys,
+            )
+        if upsert_geos:
+            self.__upsert_geos(
                 df=df,
                 namespace=namespace,
                 locality=locality,
@@ -607,9 +906,7 @@ class WriteContext:
                 max_conns=max_conns,
             )
 
-        if not create_geo:
-            self.__validate_geos(df=df, locality=locality, layer=layer)
-
+        log.debug("VALIDATING COLUMNS")
         self.__validate_columns(columns)
 
         # TODO: Check to see if grabbing all of the columns and then filtering
@@ -622,6 +919,8 @@ class WriteContext:
             _load_column_values(self.columns, df, columns, batch_size, max_conns)
         )
 
+        log.debug("FINISHED LOADING DATAFRAME")
+
 
 # based on https://stackoverflow.com/a/61478547
 async def gather_batch(coros, n):
@@ -632,7 +931,7 @@ async def gather_batch(coros, n):
         async with semaphore:
             return await coro
 
-    return await asyncio.gather(*(sem_coro(c) for c in coros))
+    return await asyncio.gather(*(sem_coro(c) for c in coros), return_exceptions=True)
 
 
 async def _load_geos(
@@ -643,12 +942,41 @@ async def _load_geos(
     max_conns: Optional[int],
 ) -> list[Geography]:
     """Asynchronously loads geographies in batches."""
+    log.debug("IN THE LOAD GEOS FUNCTION")
     geo_pairs = list(geos.items())
     tasks = []
+    log.debug("BEFORE ASYNC BULK FOR GEOS %s", geo_pairs[0])
     async with repo.async_bulk(namespace, max_conns) as ctx:
         for idx in range(0, len(geo_pairs), batch_size):
             chunk = dict(geo_pairs[idx : idx + batch_size])
             tasks.append(ctx.create(chunk))
+        results = await gather_batch(tasks, max_conns)
+
+    # TODO: more sophisticated error handling -- which batches were successful?
+    # what can be retried? etc.
+    for result in results:
+        if isinstance(result, Exception):
+            raise result
+
+
+async def _update_geos(
+    *,
+    repo: GeographyRepo,
+    geos: dict[str, GeoValType],
+    namespace: str,
+    batch_size: int,
+    max_conns: Optional[int],
+    allow_empty_polys: bool,
+) -> list[Geography]:
+    """Asynchronously loads geographies in batches."""
+    log.debug("IN THE LOAD GEOS FUNCTION")
+    geo_pairs = list(geos.items())
+    tasks = []
+    log.debug("BEFORE ASYNC BULK FOR GEOS %s", geo_pairs[0])
+    async with repo.async_bulk(namespace, max_conns) as ctx:
+        for idx in range(0, len(geo_pairs), batch_size):
+            chunk = dict(geo_pairs[idx : idx + batch_size])
+            tasks.append(ctx.update(chunk, allow_empty_polys=allow_empty_polys))
         results = await gather_batch(tasks, max_conns)
 
     # TODO: more sophisticated error handling -- which batches were successful?

--- a/gerrydb/exceptions.py
+++ b/gerrydb/exceptions.py
@@ -51,3 +51,7 @@ class GraphLoadError(GerryDBError):
 
 class GerryPathError(GerryDBError):
     """Raised when an invalid path is provided. Generally, this means invalid characters are present"""
+
+
+class ForkingError(GerryDBError):
+    """Raised when a migration cannot be performed."""

--- a/gerrydb/exceptions.py
+++ b/gerrydb/exceptions.py
@@ -45,5 +45,9 @@ class ViewLoadError(GerryDBError):
     """Raised when a view cannot be loaded (e.g. from a GeoPackage)."""
 
 
+class GraphLoadError(GerryDBError):
+    """Raised when a graph cannot be loaded (e.g. from a GeoPackage)."""
+
+
 class GerryPathError(GerryDBError):
     """Raised when an invalid path is provided. Generally, this means invalid characters are present"""

--- a/gerrydb/logging.py
+++ b/gerrydb/logging.py
@@ -1,0 +1,35 @@
+import logging
+import colorlog
+import os
+
+log = logging.getLogger("gerrydb")
+
+
+def setup_logging(level=logging.INFO):
+    if log.hasHandlers():
+        return
+
+    handler = colorlog.StreamHandler()
+    handler.setFormatter(
+        colorlog.ColoredFormatter(
+            "%(log_color)s%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+            log_colors={
+                "DEBUG": "cyan",
+                "INFO": "green",
+                "WARNING": "yellow",
+                "ERROR": "red",
+                "CRITICAL": "bold_red",
+            },
+        )
+    )
+    log.setLevel(level)
+    log.addHandler(handler)
+    log.propagate = False
+
+    log.debug("gerrydb logger is configured.")
+
+
+if os.getenv("GERRYDB_DEBUG"):
+    setup_logging(level=logging.DEBUG)
+else:
+    setup_logging(level=logging.INFO)

--- a/gerrydb/repos/column.py
+++ b/gerrydb/repos/column.py
@@ -23,9 +23,7 @@ from gerrydb.schemas import (
     Geography,
 )
 
-import logging
-
-log = logging.getLogger()
+from gerrydb.logging import log
 
 
 class ColumnRepo(NamespacedObjectRepo[Column]):
@@ -235,6 +233,7 @@ class ColumnRepo(NamespacedObjectRepo[Column]):
             params["transport"] = httpx.AsyncHTTPTransport(retries=1)
             client = httpx.AsyncClient(**params)
 
+        # Peter Note: the geos are generally strings here
         json = [
             ColumnValue(
                 path=(
@@ -246,6 +245,7 @@ class ColumnRepo(NamespacedObjectRepo[Column]):
             ).dict()
             for geo, value in values.items()
         ]
+        log.debug("PUT request to %s", clean_path)
         response = await client.put(
             clean_path,
             json=json,

--- a/gerrydb/repos/geo_layer.py
+++ b/gerrydb/repos/geo_layer.py
@@ -10,6 +10,7 @@ from gerrydb.repos.base import (
     write_context,
 )
 from gerrydb.schemas import Geography, GeoLayer, GeoLayerCreate, GeoSetCreate, Locality
+from gerrydb.logging import log
 
 
 class GeoLayerRepo(NamespacedObjectRepo[GeoLayer]):
@@ -67,6 +68,10 @@ class GeoLayerRepo(NamespacedObjectRepo[GeoLayer]):
             RequestError: If the mapping cannot be created on the server side,
                 or if the parameters fail validation.
         """
+        log.debug("TOP OF MAP LOCALITY")
+        log.debug(
+            f"MAKING PUT REQUEST TO {self.base_url}/{layer.namespace}/{layer.path}"
+        )
         response = self.ctx.client.put(
             f"{self.base_url}/{layer.namespace}/{layer.path}",
             params={

--- a/gerrydb/repos/geography.py
+++ b/gerrydb/repos/geography.py
@@ -4,13 +4,14 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional, Tuple, Union
 
 import httpx
+from http import HTTPStatus
 import msgpack
 import shapely.wkb
 from shapely import Point
 from shapely.geometry.base import BaseGeometry
 import json
 
-from gerrydb.exceptions import RequestError
+from gerrydb.exceptions import RequestError, ForkingError
 from gerrydb.repos.base import (
     NAMESPACE_ERR,
     NamespacedObjectRepo,
@@ -27,12 +28,7 @@ if TYPE_CHECKING:
 GeoValType = Union[None, BaseGeometry, Tuple[Optional[BaseGeometry], Optional[Point]]]
 GeosType = dict[Union[str, Geography], GeoValType]
 
-import logging
-
-logging.basicConfig(
-    level=logging.INFO,
-)
-logger = logging.getLogger(__name__)
+from gerrydb.logging import log
 
 
 def _importer_params(ctx: "WriteContext", namespace: str) -> dict[str, Any]:
@@ -177,7 +173,12 @@ class AsyncGeoImporter:
         return await self._send(geographies, method="POST")
 
     @err("Failed to update geographies")
-    async def update(self, geographies: GeosType) -> list[Geography]:
+    async def update(
+        self,
+        geographies: GeosType,
+        *,
+        allow_empty_polys: bool,
+    ) -> list[Geography]:
         """Updates the shapes of one or more geographies.
 
         Args:
@@ -190,9 +191,18 @@ class AsyncGeoImporter:
         Returns:
             A list of updated geographies.
         """
-        return await self._send(geographies, method="PATCH")
+        return await self._send(
+            geographies,
+            method="PATCH",
+            queries={"allow_empty_polys": allow_empty_polys},
+        )
 
-    async def _send(self, geographies: GeosType, method: str) -> list[Geography]:
+    async def _send(
+        self,
+        geographies: GeosType,
+        method: str,
+        queries: Optional[dict[str, str]] = None,
+    ) -> list[Geography]:
         """Creates or updates one or more geographies."""
 
         geos = _serialize_geos(geographies)
@@ -206,10 +216,11 @@ class AsyncGeoImporter:
                 "accept": "application/msgpack",
                 "content-type": "application/msgpack",
             },
+            params=queries or {},
         )
         if response.status_code == 422:
             json_content = json.loads(response.content)
-            logger.info(
+            log.debug(
                 f"422 for Request: {method},\n\tAt: {self.repo.base_url}/{self.namespace}\n\tBody: {json_content}"
             )
 
@@ -239,6 +250,7 @@ class GeographyRepo(NamespacedObjectRepo[Geography]):
     @online
     def bulk(self, namespace: Optional[str] = None) -> GeoImporter:
         """Creates a context for creating and updating geographies."""
+        log.debug("IN CREATE BULK GEOGRAPHY REPO")
         namespace = self.session.namespace if namespace is None else namespace
         if namespace is None:
             raise RequestError(NAMESPACE_ERR)
@@ -251,21 +263,101 @@ class GeographyRepo(NamespacedObjectRepo[Geography]):
         self, namespace: Optional[str] = None, max_conns: Optional[int] = None
     ) -> AsyncGeoImporter:
         """Creates an asynchronous context for creating and updating geographies."""
+        log.debug("IN ASYNC CREATE BULK GEOGRAPHY REPO")
         namespace = self.session.namespace if namespace is None else namespace
         if namespace is None:
             raise RequestError(NAMESPACE_ERR)
 
         return AsyncGeoImporter(repo=self, namespace=namespace, max_conns=max_conns)
 
-    # TODO: get()
     @namespaced
     @online
     @err("Failed to load geographies")
-    def all_paths(self, fips: str, layer_name: str) -> list[str]:
+    def all_paths(
+        self, path: str, namespace: Optional[str] = None, *, layer_name: str
+    ) -> list[str]:
+        if namespace is None:
+            namespace = self.session.namespace
+
         response = self.session.client.get(
-            f"/__list_geo/{self.session.namespace}/{fips}/{layer_name}"
+            f"/__geography_list/{namespace}/{path}/{layer_name}"
         )
         response.raise_for_status()
         response_json = response.json()
 
         return response_json
+
+    @namespaced
+    @online
+    def check_forkability(
+        self,
+        path: str,
+        namespace: Optional[str] = None,
+        *,
+        layer_name: str,
+        source_namespace: Optional[str] = None,
+        source_layer_name: str,
+        allow_extra_source_geos: bool = False,
+        allow_empty_polys: bool = False,
+    ) -> list[Tuple[str, str]]:
+        """Checks whether or not data can be forkd from one namesspace to another."""
+        try:
+            log.debug("Getting forkability")
+            response = self.session.client.get(
+                f"/__geography_fork/{namespace}/{path}/{layer_name}?mode=compare&source_namespace={source_namespace}&source_layer={source_layer_name}&allow_extra_source_geos={allow_extra_source_geos}&allow_empty_polys={allow_empty_polys}"
+            )
+            log.debug(response)
+            response.raise_for_status()
+
+        except Exception as e:
+            if (
+                response.status_code == HTTPStatus.CONFLICT
+                or response.status_code == HTTPStatus.FORBIDDEN
+            ):
+                raise ForkingError(
+                    f"Forking failed for the following reason: "
+                    f"{e.response.json().get('detail', 'No details provided.')}",
+                )
+            raise e
+        return [(item[0], item[1]) for item in response.json()]
+
+    @namespaced
+    @online
+    def fork_geos(
+        self,
+        path: str,
+        namespace: Optional[str] = None,
+        *,
+        layer_name: str,
+        source_namespace: Optional[str] = None,
+        source_layer_name: str,
+        allow_extra_source_geos: bool = False,
+        allow_empty_polys: bool = False,
+    ) -> bool:
+        """Fork the geographies from one namespace into another"""
+        self.check_forkability(
+            path=path,
+            namespace=namespace,
+            layer_name=layer_name,
+            source_namespace=source_namespace,
+            source_layer_name=source_layer_name,
+            allow_extra_source_geos=allow_extra_source_geos,
+            allow_empty_polys=allow_empty_polys,
+        )
+
+        try:
+            response = self.session.client.post(
+                f"/__geography_fork/{namespace}/{path}/{layer_name}?mode=compare&source_namespace={source_namespace}&source_layer={source_layer_name}&allow_extra_source_geos={allow_extra_source_geos}&allow_empty_polys={allow_empty_polys}"
+            )
+            response.raise_for_status()
+
+        except Exception as e:
+            if (
+                response.status_code == HTTPStatus.CONFLICT
+                or response.status_code == HTTPStatus.FORBIDDEN
+            ):
+                raise ForkingError(
+                    f"Forking failed for the following reason: "
+                    f"{e.response.json().get('detail', 'No details provided.')}",
+                )
+            raise e

--- a/gerrydb/repos/graph.py
+++ b/gerrydb/repos/graph.py
@@ -31,8 +31,7 @@ from pathlib import Path
 import json
 import networkx as nx
 import shapely
-
-log = logging.getLogger()
+from gerrydb.logging import log
 
 try:
     import gerrychain
@@ -116,7 +115,7 @@ class DBGraph:
         self._conn = conn
 
         # Actually load the graph.
-        print("INCLUDE GEOMETRIES", include_geometries)
+        log.debug("INCLUDE GEOMETRIES %s", include_geometries)
         self.graph = self.to_networkx(include_geometries=include_geometries)
 
     @classmethod
@@ -125,7 +124,7 @@ class DBGraph:
         path: Path,
     ) -> "DBGraph":
         """Loads a graph from a GeoPackage."""
-        print("IN GRAPH FROM GPKG")
+        log.debug("IN GRAPH FROM GPKG")
         start = time.perf_counter()
         if isinstance(path, io.BytesIO):
             path.seek(0)
@@ -156,7 +155,7 @@ class DBGraph:
             )
         ret = cls(meta=GraphMeta(**raw_meta), gpkg_path=path, conn=conn)
         end = time.perf_counter()
-        print(f"Time to convert gpkg: {end - start}")
+        log.debug(f"Time to convert gpkg: {end - start}")
         return ret
 
     def to_networkx(
@@ -164,7 +163,7 @@ class DBGraph:
         include_geometries: bool = False,
     ) -> nx.Graph:
         """Loads a graph from a GeoPackage."""
-        print("IN TO NETWORKX")
+        log.debug("IN TO NETWORKX")
         raw_cols = self._conn.execute(
             "SELECT name from pragma_table_info(?)",
             (f"{self.path}__geometry",),
@@ -214,6 +213,12 @@ class DBGraph:
                 )
             graph.add_node(path, **node_attrs)
 
+        edge_query = self._conn.execute(
+            "SELECT path_1, path_2, weights FROM gerrydb_graph_edge"
+        )
+        for edge in edge_query:
+            graph.add_edge(edge[0], edge[1], attr=edge[2])
+
         return graph
 
     def __repr__(self):
@@ -261,6 +266,7 @@ class GraphRepo(NamespacedObjectRepo[Graph]):
             The new districting plan in the form of a gerrydb `Graph` schema
             object.
         """
+        log.debug("IN GRAPH REPO CREATE")
         response = self.ctx.client.post(
             f"{self.base_url}/{namespace}",
             json=GraphCreate(
@@ -289,14 +295,16 @@ class GraphRepo(NamespacedObjectRepo[Graph]):
             response.raise_for_status()
         except Exception as e:
             log.error(f"{e}")
-            log.info(
+            log.error(
                 f"Failed to create graph. Details: {response.json().get('detail', 'No details provided.')}"
             )
 
         graph_meta = self.schema(**response.json())
 
+        log.debug("THE GRAPH PATH IS %s", graph_meta.path)
+        log.debug("THE GRAPH NAMESPACE IS %s", graph_meta.namespace)
         gpkg_path = self._get(path=graph_meta.path, namespace=graph_meta.namespace)
-        print("THE PATH IS", gpkg_path)
+        log.debug("THE GPKG PATH IS %s", gpkg_path)
         return DBGraph.from_gpkg(gpkg_path)
 
     def _get(self, path: str, namespace: str, request_timeout: int = 1200) -> Path:
@@ -307,8 +315,8 @@ class GraphRepo(NamespacedObjectRepo[Graph]):
             f"{self.base_url}/{namespace}/{path}",
             timeout=request_timeout,
         )
-        print("THE GPKG RESPONSE IS", gpkg_response)
-        print(gpkg_response.headers)
+        log.debug("THE GPKG RESPONSE IS %s", gpkg_response)
+        log.debug("THE GPKG RESPONSE HEADERS ARE %s", gpkg_response.headers)
 
         if gpkg_response.status_code >= 400:
             gpkg_response.raise_for_status()
@@ -343,13 +351,11 @@ class GraphRepo(NamespacedObjectRepo[Graph]):
             RequestError: If the graph cannot be retrieved on the server side,
                 if the parameters fail validation, or if no namespace is provided.
         """
-        print("IN GET")
-        print("The namespace is", namespace)
         gpkg_path = self.session.cache.get_graph_gpkg(
             namespace=normalize_path(namespace, path_length=1),
             path=normalize_path(path),
         )
         if gpkg_path is None:
             gpkg_path = self._get(path, namespace, request_timeout)
-        print("THE PATH IS", gpkg_path)
+        log.debug("THE GPKG PATH IS %s", gpkg_path)
         return DBGraph.from_gpkg(gpkg_path)

--- a/gerrydb/repos/graph.py
+++ b/gerrydb/repos/graph.py
@@ -3,6 +3,9 @@
 from typing import Optional, Union
 
 import networkx as nx
+import sqlite3
+import io
+from datetime import datetime
 
 from gerrydb.repos.base import (
     NamespacedObjectRepo,
@@ -11,7 +14,207 @@ from gerrydb.repos.base import (
     online,
     write_context,
 )
-from gerrydb.schemas import GeoLayer, Graph, GraphCreate, Locality
+from gerrydb.exceptions import GraphLoadError
+from gerrydb.schemas import (
+    GeoLayer,
+    Graph,
+    GraphMeta,
+    Locality,
+    ObjectMeta,
+    GraphCreate,
+    GraphMeta,
+    BaseGeometry,
+)
+import time
+from pathlib import Path
+import json
+import networkx as nx
+import shapely
+
+try:
+    import gerrychain
+except ImportError:
+    gerrychain = None
+
+
+_EXPECTED_META_KEYS = {
+    "created_at",
+    "description",
+    "layer",
+    "locality",
+    "meta",
+    "namespace",
+    "path",
+    "proj",
+}
+_EXPECTED_TABLES = {
+    "gerrydb_geo_meta",
+    "gerrydb_geo_attrs",
+    "gerrydb_graph_meta",
+}
+# by flag (see https://www.geopackage.org/spec/#gpb_format)
+_GPKG_ENVELOPE_BYTES = {
+    0: 0,
+    1: 32,
+    2: 48,
+    3: 48,
+    4: 64,
+}
+
+
+def _load_gpkg_geometry(geom: bytes) -> BaseGeometry:
+    """Loads a geometry from a raw GeoPackage WKB blob."""
+    # header format: https://www.geopackage.org/spec/#gpb_format
+    if geom == None:
+        raise ValueError("Invalid GeoPackage geometry: empty geometry.")
+
+    envelope_flag = (geom[3] & 0b00001110) >> 1
+    try:
+        envelope_bytes = _GPKG_ENVELOPE_BYTES[envelope_flag]
+    except KeyError:
+        raise ValueError("Invalid GeoPackage geometry: bad envelope flag.")
+
+    wkb_offset = envelope_bytes + 8
+    return shapely.wkb.loads(geom[wkb_offset:])
+
+
+class DBGraph:
+    """Rendered Graph"""
+
+    namespace: str
+    path: str
+    locality: Locality
+    layer: GeoLayer
+    meta: ObjectMeta
+    created_at: datetime
+    proj: Optional[str]
+    graph: nx.Graph
+
+    _gpkg_path: Path
+    _conn: sqlite3.Connection
+
+    def __init__(
+        self,
+        meta: GraphMeta,
+        gpkg_path: Path,
+        conn: sqlite3.Connection,
+        include_geometries: bool = False,
+    ):
+        self.namespace = meta.namespace
+        self.path = meta.path
+        self.locality = meta.locality
+        self.layer = meta.layer
+        self.meta = meta.meta
+        self.created_at = meta.created_at
+        self.proj = meta.proj
+
+        self._gpkg_path = gpkg_path
+        self._conn = conn
+
+        # Actually load the graph.
+        self.graph = self.to_networkx(
+            self._gpkg_path, include_geometries=include_geometries
+        )
+
+    @classmethod
+    def from_gpkg(
+        cls,
+        path: Path,
+    ) -> "DBGraph":
+        """Loads a graph from a GeoPackage."""
+        print("IN GRAPH FROM GPKG")
+        start = time.perf_counter()
+        if isinstance(path, io.BytesIO):
+            path.seek(0)
+            conn = sqlite3.connect(
+                "file:cached_view?mode=memory&cache=shared", uri=True
+            )
+            conn.executescript(path.read().decode("utf-8"))
+        else:
+            conn = sqlite3.connect(path)
+
+        tables = conn.execute(
+            "SELECT name FROM sqlite_master WHERE "
+            "type ='table' AND name NOT LIKE 'sqlite_%'"
+        ).fetchall()
+        missing_tables = _EXPECTED_TABLES - set(table[0] for table in tables)
+        if missing_tables:
+            raise GraphLoadError(
+                "Cannot load graph. Does the GeoPackage have GerryDB "
+                f"extensions? (missing table(s): {', '.join(missing_tables)})"
+            )
+
+        meta_rows = conn.execute("SELECT key, value FROM gerrydb_graph_meta").fetchall()
+        raw_meta = {row[0]: json.loads(row[1]) for row in meta_rows}
+        missing_keys = _EXPECTED_META_KEYS - set(raw_meta)
+        if missing_keys:
+            raise GraphLoadError(
+                f"Cannot load graph metadata. (missing keys: {', '.join(missing_keys)})"
+            )
+        ret = cls(meta=GraphMeta(**raw_meta), gpkg_path=path, conn=conn)
+        end = time.perf_counter()
+        print(f"Time to convert gpkg: {end - start}")
+        return ret
+
+    def to_networkx(
+        self,
+        include_geometries: bool = False,
+    ) -> nx.Graph:
+        """Loads a graph from a GeoPackage."""
+        print("IN TO NETWORKX")
+        raw_cols = self._conn.execute(
+            "SELECT name from pragma_table_info(?)",
+            (f"{self.path}__geometry",),
+        ).fetchall()
+
+        if set(raw_cols) != {("fid",), ("geography",), ("path",)}:
+            raise GraphLoadError(
+                "Unexpected or missing columns in Graph Geopackage Geometry table."
+                " Expected columns: fid, geography, path."
+                f" Found columns: {set(raw_cols)}"
+            )
+
+        columns = ["path", "geography"] if include_geometries else ["path"]
+        prefixed_columns = [f"{self.path}__geometry.{col}" for col in columns]
+
+        join_clauses = []
+
+        if include_geometries:
+            # Join geographic layers: add internal points.
+            columns.append("internal_point")
+            prefixed_columns.append(f"{self.path}__internal_points.internal_point")
+            join_clauses.append(
+                f"JOIN {self.path}__internal_points "
+                f"ON {self.path}__geometry.path = {self.path}__internal_points.path"
+            )
+
+        query = f"SELECT {', '.join(prefixed_columns)} FROM {self.path}__geometry "
+        query += " ".join(join_clauses)
+
+        # Load nodes with selected attributes.
+        graph = nx.Graph()
+        for row in self._conn.execute(query):
+            node_attrs = dict(zip(columns, row))
+            path = node_attrs["path"]
+            del node_attrs["path"]
+            if include_geometries:
+                node_attrs["geometry"] = (
+                    None
+                    if node_attrs["geography"] is None
+                    else _load_gpkg_geometry(node_attrs["geography"])
+                )
+                del node_attrs["geography"]
+                node_attrs["internal_point"] = (
+                    None
+                    if node_attrs["internal_point"] is None
+                    else _load_gpkg_geometry(node_attrs["internal_point"])
+                )
+            graph.add_node(path, **node_attrs)
+
+        return graph
+
+    def __repr__(self):
+        return f"DBGraph(path={self.path}, namespace={self.namespace}, locality={self.locality}, layer={self.layer}, meta={self.meta}, created_at={self.created_at}, proj={self.proj})"
 
 
 class GraphRepo(NamespacedObjectRepo[Graph]):
@@ -80,3 +283,25 @@ class GraphRepo(NamespacedObjectRepo[Graph]):
         )
         response.raise_for_status()
         return self.schema(**response.json())
+
+    # @namespaced
+    # @online
+    def get(
+        self,
+        path: str,
+        namespace: Optional[str] = None,
+        request_timeout: int = 1200,
+    ) -> Graph:
+        """Gets a graph.
+
+        Raises:
+            RequestError: If the graph cannot be retrieved on the server side,
+                if the parameters fail validation, or if no namespace is provided.
+        """
+        # gpkg_path = self.session.cache.get_graph_gpkg(
+        #     namespace=normalize_path(namespace, path_length=1),
+        #     path=normalize_path(path),
+        # )
+        # if gpkg_path is None:
+        #     gpkg_path = self._get(path, namespace, request_timeout)
+        return DBGraph.from_gpkg(path)

--- a/gerrydb/repos/view.py
+++ b/gerrydb/repos/view.py
@@ -3,7 +3,7 @@
 import json
 import io
 import sqlite3
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Generator, Optional, Union
 
@@ -34,12 +34,9 @@ from gerrydb.schemas import (
     ViewMeta,
     ViewTemplate,
 )
+from gerrydb.logging import log
 
-import logging
 import time
-
-
-logger = logging.getLogger()
 
 
 _EXPECTED_META_KEYS = {
@@ -76,6 +73,10 @@ def _load_gpkg_geometry(geom: bytes) -> BaseGeometry:
     # header format: https://www.geopackage.org/spec/#gpb_format
     if geom == None:
         raise ValueError("Invalid GeoPackage geometry: empty geometry.")
+
+    if not geom.startswith(b"GP"):
+        # pure WKB → hand it straight to Shapely
+        return shapely.wkb.loads(geom)
 
     envelope_flag = (geom[3] & 0b00001110) >> 1
     try:
@@ -120,7 +121,7 @@ class View:
     @classmethod
     def from_gpkg(cls, path: Path) -> "View":
         """Loads a view from a GeoPackage."""
-        logger.debug("in view.from_gpkg")
+        log.debug("in view.from_gpkg")
         start = time.perf_counter()
         if isinstance(path, io.BytesIO):
             path.seek(0)
@@ -131,6 +132,7 @@ class View:
         else:
             conn = sqlite3.connect(path)
 
+        log.debug("Loading view from %s", path)
         tables = conn.execute(
             "SELECT name FROM sqlite_master WHERE "
             "type ='table' AND name NOT LIKE 'sqlite_%'"
@@ -151,13 +153,15 @@ class View:
             )
         ret = cls(meta=ViewMeta(**raw_meta), gpkg_path=path, conn=conn)
         end = time.perf_counter()
-        logger.debug(f"Time to convert gpkg: {end - start}")
+        log.debug(f"Time to convert gpkg: {end - start}")
         return ret
 
     def to_df(
         self, plans: bool = False, internal_points: bool = False
     ) -> gpd.GeoDataFrame:
         """Loads the view as a GeoDataFrame."""
+        log.debug("The gpkg path is %s", self._gpkg_path)
+        log.debug("The layer is %s", self.path)
         gdf = gpd.read_file(self._gpkg_path, layer=self.path).set_index("path")
 
         if plans:
@@ -377,43 +381,47 @@ class ViewRepo(NamespacedObjectRepo[ViewMeta]):
             The new view.
         """
         start = time.perf_counter()
+        log.debug("TOP OF CREATE VIEW")
+        if valid_at is None:
+            valid_at = datetime.now(timezone.utc)
+
+        payload = ViewCreate(
+            path=path,
+            template=template if isinstance(template, str) else template.full_path,
+            locality=(
+                locality if isinstance(locality, str) else locality.canonical_path
+            ),
+            layer=layer if isinstance(layer, str) else layer.full_path,
+            graph=(
+                None
+                if graph is None
+                else (graph if isinstance(graph, str) else graph.full_path)
+            ),
+            valid_at=valid_at,
+            proj=proj,
+        )
+
         response = self.ctx.client.post(
             f"{self.base_url}/{namespace}",
-            json=ViewCreate(
-                path=path,
-                template=template if isinstance(template, str) else template.full_path,
-                locality=(
-                    locality if isinstance(locality, str) else locality.canonical_path
-                ),
-                layer=layer if isinstance(layer, str) else layer.full_path,
-                graph=(
-                    None
-                    if graph is None
-                    else (graph if isinstance(graph, str) else graph.full_path)
-                ),
-                valid_at=valid_at,
-                proj=proj,
-            ).dict(),
+            json=payload.dict(),
             timeout=10000,
         )
         try:
             response.raise_for_status()
         except Exception as e:
-            logger.error(f"{e}")
-            # print(response)
-            logger.info(
+            log.error(f"{e}")
+            log.info(
                 f"Failed to create view. Details: {response.json().get('detail', 'No details provided.')}"
             )
-            # logger.debug(response.json())
             raise e
         end = time.perf_counter()
-        logger.debug(f"Time to create view: {end - start}")
+        log.debug(f"Time to create view: {end - start}")
         start = time.perf_counter()
         view_meta = ViewMeta(**response.json())
-        logger.debug(f"Time to parse view: {time.perf_counter() - start}")
+        log.debug(f"Time to parse view: {time.perf_counter() - start}")
         start = time.perf_counter()
         gpkg_path = self._get(path=view_meta.path, namespace=view_meta.namespace)
-        logger.debug(f"Time to get gpkg_path: {time.perf_counter() - start}")
+        log.debug(f"Time to get gpkg_path: {time.perf_counter() - start}")
         return View.from_gpkg(gpkg_path)
 
     @namespaced

--- a/gerrydb/repos/view_template.py
+++ b/gerrydb/repos/view_template.py
@@ -11,6 +11,7 @@ from gerrydb.repos.base import (
     write_context,
 )
 from gerrydb.schemas import Column, ColumnSet, ViewTemplate, ViewTemplateCreate
+from gerrydb.logging import log
 
 
 def _normalize_columns(
@@ -36,8 +37,12 @@ def _normalize_columns(
             split_path = item.split("/")
             if len(split_path) == 1:
                 return_list.append(f"/columns/{namespace}/{split_path[0]}")
+            elif len(split_path) == 2:
+                return_list.append(f"columns/{split_path[0]}/{split_path[1]}")
             elif len(split_path) == 3:
-                return_list.append(f"columns/{namespace}/{split_path[-1]}")
+                if split_path[0] != "columns":
+                    raise ValueError(f"Invalid column path: {item}")
+                return_list.append(f"{split_path[0]}/{split_path[1]}/{split_path[2]}")
             else:
                 raise ValueError(
                     f"Column path must be in the form of either "
@@ -63,21 +68,26 @@ def _normalize_column_sets(
     return_list = []
 
     for item in column_sets:
-        if isinstance(item, Column):
+        if isinstance(item, ColumnSet):
             return_list.append(item.path_with_resource)
         else:
             item = normalize_path(item)
             split_path = item.split("/")
             if len(split_path) == 1:
                 return_list.append(f"/column-sets/{namespace}/{split_path[0]}")
+            elif len(split_path) == 2:
+                return_list.append(f"/column-sets/{split_path[0]}/{split_path[1]}")
             elif len(split_path) == 3:
-                return_list.append(f"/column-sets/{namespace}/{split_path[-1]}")
+                if split_path[0] != "column-sets":
+                    raise ValueError(f"Invalid column set path: {item}")
+                return_list.append(f"/{split_path[0]}/{namespace}/{split_path[-1]}")
             else:
                 raise ValueError(
                     f"Column_set path must be in the form of either "
                     "/column-sets/namespace/column_set_name or just column_set_name"
                 )
 
+    log.debug("COLUMN SETS: %s", return_list)
     return return_list
 
 

--- a/gerrydb/schemas.py
+++ b/gerrydb/schemas.py
@@ -432,6 +432,19 @@ class ViewCreate(ViewBase):
     valid_at: Optional[datetime] = None
     proj: Optional[str] = None
 
+    class Config:
+        # Whenever you call model.json(), turn datetimes into ISO strings
+        json_encoders = {datetime: lambda dt: dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")}
+
+    def dict(self, *args, **kwargs):
+        data = super().dict(*args, **kwargs)
+
+        # now post‑process valid_at if it's still a datetime
+        va = data.get("valid_at")
+        if isinstance(va, datetime):
+            data["valid_at"] = va.strftime("%Y-%m-%d %H:%M:%S.%fZ")
+        return data
+
 
 class ViewMeta(ViewBase):
     """View metadata."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,7 +125,7 @@ def client_with_ia_layer_loc(ia_dataframe, ia_column_meta):
         ctx.load_dataframe(
             df=ia_dataframe,
             columns=columns,
-            create_geo=True,
+            create_geos=True,
             namespace=client.namespace,
             layer=layer,
             locality=locality,

--- a/tests/repos/test_base.py
+++ b/tests/repos/test_base.py
@@ -9,7 +9,7 @@ import pytest
 
 from gerrydb.client import GerryDB, WriteContext
 from gerrydb.exceptions import OnlineError, ResultError, WriteContextError
-from gerrydb.repos.base import err, online, parse_path, write_context
+from gerrydb.repos.base import err, online, write_context
 
 
 @dataclass
@@ -66,14 +66,3 @@ def test_repos_write_context_decorator__no_write_context(dummy_repo_offline):
 
     with pytest.raises(WriteContextError):
         fn(dummy_repo_offline)
-
-
-def test_repos_parse_path__valid():
-    namespace, path_in_namespace = parse_path("/a/b")
-    assert namespace == "a"
-    assert path_in_namespace == "b"
-
-
-def test_repos_parse_path__invalid():
-    with pytest.raises(KeyError, match="must contain"):
-        parse_path("a")

--- a/tests/repos/test_column.py
+++ b/tests/repos/test_column.py
@@ -21,7 +21,7 @@ def test_column_repo_create_get(client_ns, column):
     assert col.type == ColumnType.INT
     assert client_ns.columns["total_pop"] == col
     assert client_ns.columns["totpop"] == col
-    assert client_ns.columns[f"/{client_ns.namespace}/total_pop"] == col
+    assert client_ns.columns[(f"{client_ns.namespace}", "total_pop")] == col
 
 
 @pytest.mark.vcr

--- a/tests/repos/test_column_set.py
+++ b/tests/repos/test_column_set.py
@@ -18,13 +18,13 @@ def test_column_set_repo_create_get(client_ns, pop_column_meta, vap_column_meta)
         col_set = ctx.column_sets.create(
             path="totals",
             description="Total population columns",
-            columns=[pop_col, "total_vap", f"/{client_ns.namespace}/total_cvap"],
+            columns=[pop_col, "total_vap", f"{client_ns.namespace}/total_cvap"],
         )
 
     col_paths = set(col.canonical_path for col in col_set.columns)
     assert col_paths == {"total_pop", "total_vap", "total_cvap"}
     assert client_ns.column_sets["totals"] == col_set
-    assert client_ns.column_sets[f"/{client_ns.namespace}/totals"] == col_set
+    assert client_ns.column_sets[(f"{client_ns.namespace}", "totals")] == col_set
 
 
 @pytest.mark.vcr

--- a/tests/repos/test_geo_layer.py
+++ b/tests/repos/test_geo_layer.py
@@ -7,14 +7,14 @@ import pytest
 def test_geo_layer_repo_create_get(client_ns):
     with client_ns.context(notes="adding a geographic layer") as ctx:
         layer = ctx.geo_layers.create(
-            "blocks/2020",
+            "blocks-2020",
             description="2020 Census blocks",
             source_url="https://www.census.gov/",
         )
 
     assert layer.description == "2020 Census blocks"
-    assert client_ns.geo_layers["blocks/2020"] == layer
-    assert client_ns.geo_layers[f"/{client_ns.namespace}/blocks/2020"] == layer
+    assert client_ns.geo_layers["blocks-2020"] == layer
+    assert client_ns.geo_layers[(f"{client_ns.namespace}", "blocks-2020")] == layer
 
 
 @pytest.mark.vcr

--- a/tests/repos/test_graph.py
+++ b/tests/repos/test_graph.py
@@ -1,5 +1,17 @@
 """Integration/VCR tests for dual graphs."""
 
+import networkx as nx
+
+
+def graphs_equal(G1: nx.Graph, G2: nx.Graph) -> bool:
+    # Quick check: same node‑set and same edge‑set
+    if set(G1.nodes) != set(G2.nodes):
+        return False
+    if set(G1.edges) != set(G2.edges):
+        return False
+
+    return True
+
 
 def test_graph_repo_create_get__valid(client_with_ia_layer_loc, ia_graph):
     client_ns, layer, locality, _ = client_with_ia_layer_loc
@@ -14,7 +26,18 @@ def test_graph_repo_create_get__valid(client_with_ia_layer_loc, ia_graph):
         )
         saved_edges = {
             (path_1.split("/")[-1], path_2.split("/")[-1])
-            for path_1, path_2, _ in graph.edges
+            for path_1, path_2 in graph.graph.edges
         }
-        assert saved_edges == set(ia_graph.edges)
-        assert ctx.graphs["ia_counties_rook"] == graph
+        sorted_saved_edges = set([tuple(sorted(edge)) for edge in saved_edges])
+        sorted_ia_graph_edges = set([tuple(sorted(edge)) for edge in ia_graph.edges])
+        assert sorted_saved_edges == sorted_ia_graph_edges
+
+        retrieved_graph = ctx.graphs["ia_counties_rook"]
+        assert graphs_equal(graph.graph, retrieved_graph.graph)
+        assert graph.namespace == retrieved_graph.namespace
+        assert graph.path == retrieved_graph.path
+        assert graph.locality == retrieved_graph.locality
+        assert graph.layer == retrieved_graph.layer
+        assert graph.meta == retrieved_graph.meta
+        assert graph.created_at == retrieved_graph.created_at
+        assert graph.proj == retrieved_graph.proj

--- a/tests/repos/test_locality.py
+++ b/tests/repos/test_locality.py
@@ -1,7 +1,6 @@
 """Integration/VCR tests for localities."""
 
 import pytest
-
 from gerrydb.schemas import LocalityCreate
 
 
@@ -9,11 +8,11 @@ from gerrydb.schemas import LocalityCreate
 def testlocality_repo_create_get(client):
     name = "Commonwealth of Massachusetts"
     with client.context(notes="adding a locality") as ctx:
-        loc = ctx.localities.create(name=name, canonical_path="ma")
+        loc = ctx.localities.create(name=name, canonical_path="ma2")
     assert loc.name == name
-    assert loc.canonical_path == "ma"
+    assert loc.canonical_path == "ma2"
 
-    assert client.localities["ma"] == loc
+    assert client.localities["ma2"] == loc
 
 
 @pytest.mark.vcr
@@ -34,6 +33,6 @@ def test_locality_repo_create_bulk(client):
 def test_locality_repo_create_all(client):
     name = "State of Vermont"
     with client.context(notes="adding a locality") as ctx:
-        ctx.localities.create(name=name, canonical_path="vt")
+        ctx.localities.create(name=name, canonical_path="vt2")
 
     assert name in [loc.name for loc in client.localities.all()]

--- a/tests/repos/test_view.py
+++ b/tests/repos/test_view.py
@@ -1,6 +1,19 @@
 """Tests for views."""
 
 import pytest
+import networkx as nx
+
+
+def graphs_equal(G1: nx.Graph, G2: nx.Graph) -> bool:
+    # Quick check: same node‑set and same edge‑set
+    if set(G1.nodes) != set(G2.nodes):
+        return False
+    edge_set_1 = set([tuple(sorted(e)) for e in G1.edges])
+    edge_set_2 = set([tuple(sorted(e)) for e in G1.edges])
+    if edge_set_1 != edge_set_2:
+        return False
+
+    return True
 
 
 @pytest.mark.vcr
@@ -77,8 +90,7 @@ def test_view_repo_view_to_dataframe(ia_view, ia_dataframe):
 def test_view_repo_view_to_graph(ia_view_with_graph, ia_graph):
     view_graph = ia_view_with_graph.to_graph()
 
-    assert set(view_graph) == set(ia_graph)
-    assert set(view_graph.edges) == set(ia_graph.edges)
+    assert graphs_equal(view_graph, ia_graph)
 
     expected_cols = set(
         "/".join(col.split("/")[2:]) for col in ia_view_with_graph.values
@@ -94,8 +106,7 @@ def test_view_repo_view_to_graph(ia_view_with_graph, ia_graph):
 def test_view_repo_view_to_graph_geo(ia_view_with_graph, ia_graph):
     view_graph = ia_view_with_graph.to_graph(geometry=True)
 
-    assert set(view_graph) == set(ia_graph)
-    assert set(view_graph.edges) == set(ia_graph.edges)
+    assert graphs_equal(view_graph, ia_graph)
 
     expected_cols = set(
         "/".join(col.split("/")[2:]) for col in ia_view_with_graph.values

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -17,7 +17,7 @@ def test_load_dataframe__with_geo__ia_counties(client_ns, ia_dataframe, ia_colum
         ctx.load_dataframe(
             df=ia_dataframe,
             columns=columns,
-            create_geo=True,
+            create_geos=True,
             namespace=client_ns.namespace,
             layer=layer,
             locality=locality,


### PR DESCRIPTION
Allows for the processing of graphs sent as gpkg files sent over the network and will change the caching schema for things like views by deconstructing them into components in the cache and then reconstructing the necessary items on the fly.

Plan is that if you pull a view with some columns and then pull another view with some overlapping columns, you only need to hit the DB to pull down the difference between the two